### PR TITLE
Remove retro

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -42,6 +42,15 @@
                 "--model",
                 "minimum-service"
             ]
-        }
+        },
+        {
+            "name": "No retro",
+            "type": "python",
+            "request": "launch",
+            "module": "muse",
+            "args": [
+                "/Users/dalonsoa/Documents/Projects/scratch/MUSE/run/example/default_sara/settings.toml",
+            ]
+        },
     ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- Add option for `standard_demand` and remove retro agents ([#35](https://github.com/SGIModel/MUSE_OS/pull/35))
 - Update main version ([#28](https://github.com/SGIModel/MUSE_OS/pull/28))
 - Update main version ([#26](https://github.com/SGIModel/MUSE_OS/pull/26))
 - Adds version numbering ([#21](https://github.com/SGIModel/MUSE_OS/pull/21))

--- a/src/muse/agents/factories.py
+++ b/src/muse/agents/factories.py
@@ -143,6 +143,10 @@ def create_newcapa_agent(
         for name in kwargs.pop("search_rules")
     ]
 
+    if not retrofit_present:
+        if "with_asset_technology" not in search_rules:
+            search_rules.insert(-1, "with_asset_technology")
+
     result = InvestingAgent(
         assets=assets,
         region=region,

--- a/src/muse/agents/factories.py
+++ b/src/muse/agents/factories.py
@@ -91,6 +91,7 @@ def create_newcapa_agent(
     capacity: xr.DataArray,
     year: int,
     region: Text,
+    share: Text,
     search_rules: Union[Text, Sequence[Text]] = "all",
     interpolation: Text = "linear",
     merge_transform: Union[Text, Mapping, Callable] = "new",
@@ -120,7 +121,6 @@ def create_newcapa_agent(
             capacity.sel(asset=existing.values, year=years)
         )
     else:
-        share = "agent_share_2"
         technologies = kwargs["technologies"]
         assets["capacity"] = _shared_capacity(
             technologies, capacity, region, share, year, interpolation=interpolation

--- a/src/muse/agents/factories.py
+++ b/src/muse/agents/factories.py
@@ -125,6 +125,7 @@ def create_newcapa_agent(
         assets["capacity"] = _shared_capacity(
             technologies, capacity, region, share, year, interpolation=interpolation
         )
+        merge_transform = "merge"
 
     kwargs = _standardize_investing_inputs(
         search_rules=search_rules,

--- a/src/muse/agents/factories.py
+++ b/src/muse/agents/factories.py
@@ -96,9 +96,14 @@ def create_newcapa_agent(
     merge_transform: Union[Text, Mapping, Callable] = "new",
     quantity: float = 0.3,
     housekeeping: Union[Text, Mapping, Callable] = "noop",
+    retrofit_present: bool = True,
     **kwargs,
 ):
-    """Creates newcapa agent from muse primitives."""
+    """Creates newcapa agent from muse primitives.
+
+    If there are no retrofit agents present in the sector, then the newcapa agent need
+    to be initialised with the initial capacity of the sector.
+    """
     from muse.filters import factory as filter_factory
     from muse.registration import name_variations
 
@@ -108,8 +113,18 @@ def create_newcapa_agent(
     existing = capacity.interp(year=year, method=interpolation) > 0
     assert set(existing.dims) == {"asset"}
     years = [capacity.year.min().values, capacity.year.max().values]
+
     assets = xr.Dataset()
-    assets["capacity"] = xr.zeros_like(capacity.sel(asset=existing.values, year=years))
+    if retrofit_present:
+        assets["capacity"] = xr.zeros_like(
+            capacity.sel(asset=existing.values, year=years)
+        )
+    else:
+        share = "agent_share_2"
+        technologies = kwargs["technologies"]
+        assets["capacity"] = _shared_capacity(
+            technologies, capacity, region, share, year, interpolation=interpolation
+        )
 
     kwargs = _standardize_investing_inputs(
         search_rules=search_rules,
@@ -272,6 +287,11 @@ def agents_factory(
         if capacity.dst_region.size == 1:
             capacity = capacity.squeeze("dst_region", drop=True)
     result = []
+
+    retrofit_present = False
+    for param in params:
+        retrofit_present = retrofit_present or param["agent_type"] == "retrofit"
+
     for param in params:
         if regions is not None and param["region"] not in regions:
             continue
@@ -283,7 +303,7 @@ def agents_factory(
         param["capacity"] = deepcopy(capacity.sel(region=param["region"]))
         param["year"] = year
         param.update(kwargs)
-        result.append(create_agent(**param))
+        result.append(create_agent(**param, retrofit_present=retrofit_present))
 
     nregs = len({u.region for u in result})
     types = [u.name for u in result]

--- a/src/muse/demand_share.py
+++ b/src/muse/demand_share.py
@@ -93,10 +93,10 @@ def factory(
     settings: Optional[Union[Text, Mapping[Text, Any]]] = None
 ) -> DEMAND_SHARE_SIGNATURE:
     if settings is None or isinstance(settings, Text):
-        name = settings or "split_demand"
+        name = settings or "new_and_retro"
         params: Mapping[Text, Any] = {}
     else:
-        name = settings.get("name", "split_demand")
+        name = settings.get("name", "new_and_retro")
         params = {k: v for k, v in settings.items() if k != "name"}
 
     function = DEMAND_SHARE[name]
@@ -325,8 +325,8 @@ def new_and_retro(
     return result
 
 
-@register_demand_share(name="split_demand")
-def split_demand(
+@register_demand_share(name="standard_demand")
+def standard_demand(
     agents: Sequence[AbstractAgent],
     market: xr.Dataset,
     technologies: xr.Dataset,

--- a/src/muse/errors.py
+++ b/src/muse/errors.py
@@ -33,3 +33,26 @@ and/or the MaxCapacityGrowth in the technodata."""
 
     def __str__(self):
         return self.msg
+
+
+class RetrofitAgentInStandardDemandShare(Exception):
+
+    msg = """A retrofit agent has been found in a 'New agents'-only demand share
+function. Make sure you remove all the retro agents from the Agents input files or use a
+demand share method that can handle both new and retro agents."""
+
+    def __str__(self):
+        return self.msg
+
+
+class AgentWithNoAssetsInDemandShare(Exception):
+
+    msg = """This error refers to an agent with no assets. To fix this error, check the
+capacity assigment to the agents. One possibility is that you have decided not
+to use "Retrofit" agents, as such you may have already removed them from the
+agent definition file and the file of technodata, the system TOML file should
+change the demand_share to "standard_demand" function in each subsector
+section for each of the selected sectors to model."""
+
+    def __str__(self):
+        return self.msg

--- a/src/muse/errors.py
+++ b/src/muse/errors.py
@@ -46,7 +46,7 @@ Check the spelling of the technology names."""
     def __str__(self):
         return self.msg
 
- 
+
 class FailedInterpolation(Exception):
     """Indicates that the initialisation fails due to interpolation"""
 
@@ -59,18 +59,18 @@ Check the spelling of the technology names in the sector data."""
     def __str__(self):
         return self.msg
 
- 
+
 class RetrofitAgentInStandardDemandShare(Exception):
 
     msg = """A retrofit agent has been found in a 'New agents'-only demand share
 function. Make sure you remove all the retro agents from the Agents input files or use a
 demand share method that can handle both new and retro agents."""
-    
+
     def __str__(self):
         return self.msg
 
 
- class AgentWithNoAssetsInDemandShare(Exception):
+class AgentWithNoAssetsInDemandShare(Exception):
 
     msg = """This error refers to an agent with no assets. To fix this error, check the
 capacity assigment to the agents. One possibility is that you have decided not
@@ -78,6 +78,6 @@ to use "Retrofit" agents, as such you may have already removed them from the
 agent definition file and the file of technodata, the system TOML file should
 change the demand_share to "standard_demand" function in each subsector
 section for each of the selected sectors to model."""
-    
+
     def __str__(self):
         return self.msg

--- a/src/muse/readers/csv.py
+++ b/src/muse/readers/csv.py
@@ -555,8 +555,8 @@ def read_csv_agent_parameters(filename) -> List:
             data["maturity_threshhold"] = row.MaturityThreshold
         if hasattr(row, "SpendLimit"):
             data["spend_limit"] = row.SpendLimit
-        if agent_type != "newcapa":
-            data["share"] = sub(r"Agent(\d)", r"agent_share_\1", row.AgentShare)
+        # if agent_type != "newcapa":
+        data["share"] = sub(r"Agent(\d)", r"agent_share_\1", row.AgentShare)
         if agent_type == "retrofit" and data["decision"] == "lexo":
             data["decision"] = "retro_lexo"
         result.append(data)

--- a/src/muse/utilities.py
+++ b/src/muse/utilities.py
@@ -582,6 +582,16 @@ def agent_concatenation(
     result = xr.concat(data.values(), dim=dim)
     if isinstance(result, xr.Dataset):
         result = result.set_coords("agent")
+    if isinstance(result, xr.DataArray):
+        if result[name].data.shape == ():
+            result = result.assign_coords(
+                {
+                    name: (
+                        dim,
+                        result[name].data[None],
+                    )
+                }
+            )
     if "year" in result.dims:
         result = result.ffill("year")
     if fill_value is not np.nan:

--- a/src/muse/utilities.py
+++ b/src/muse/utilities.py
@@ -580,7 +580,7 @@ def agent_concatenation(
     for key, datum in data.items():
         if name in datum.coords:
             raise ValueError(f"Coordinate {name} already exists")
-        if isinstance(datum, xr.DataArray):
+        if len(data) == 1 and isinstance(datum, xr.DataArray):
             data[key] = datum.assign_coords(
                 {
                     name: (

--- a/tests/test_subsector.py
+++ b/tests/test_subsector.py
@@ -79,6 +79,10 @@ def test_subsector_noninvesting_aggregation(market, model, technologies, tmp_pat
             param["capacity"] = deepcopy(capa.sel(region=param["region"]))
         else:
             param["capacity"] = xr.zeros_like(capa.sel(region=param["region"]))
+
+        if "share" in param:
+            del param["share"]
+
         param["agent_type"] = "default"
         param["category"] = "trade"
         param["year"] = 2020


### PR DESCRIPTION
# Description

Adds a new version for the demand share that do not use retro agents - indeed, if they are present in the `Agents.csv` file, it will complain. Using this new demand share is set in the TOML file for each of the sectors. 

Fixes # NA

## Type of change

Please add a line in the relevant section of
[CHANGELOG.md](https://github.com/SGIModel/StarMuse/blob/development/CHANGELOG.md) to
document the change (include PR #) - note reverse order of PR #s.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass: `$ python -m pytest`
- [x] The documentation builds and looks OK: `$ python setup.py build_sphinx`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
