### PR TITLE
Fatal error if commodities are not consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Features
 
-- Adds cache of quan tities ([#15](https://github.com/SGIModel/MUSE_OS/pull/15))
+- Adds cache of quantities ([#15](https://github.com/SGIModel/MUSE_OS/pull/15))
 - Adds trade tutorial to the documentation
 - Updated branch names on pipelines ([#9](https://github.com/SGIModel/MUSE_OS/issues/9))
 - Edited default package name from StarMUSE to MUSE ([#4](https://github.com/SGIModel/MUSE_OS/issues/4))
@@ -27,6 +27,7 @@
 
 ## Bug fixes
 
+- Raise error for inconsistent commodities ([#38](https://github.com/SGIModel/MUSE_OS/issues/38))
 - Fix error in black ([#32](https://github.com/SGIModel/MUSE_OS/pull/32))
 - Fixes the dead links in the documentation now that the repository is open-sourced ([#3](https://github.com/SGIModel/MUSE_OS/issues/3))
 - Ensures that the adhoc and scipy solvers require the same input in the agents file to minimise and maximise. Specifically, both solvers now require TRUE for minimisation and FALSE for maximisation ([#845](https://github.com/SGIModel/StarMuse/issues/845))

--- a/src/muse/readers/csv.py
+++ b/src/muse/readers/csv.py
@@ -358,8 +358,11 @@ def read_technologies(
     if isinstance(commodities, xr.Dataset):
         if result.commodity.isin(commodities.commodity).all():
             result = result.merge(commodities.sel(commodity=result.commodity))
+
         else:
-            logger.warn("Commodities missing in global commodities file.")
+            raise IOError(
+                f"Commodities not found in global commodities file. Check spelling of names across input and sector data."
+            )
 
     result["comm_usage"] = (
         "commodity",

--- a/src/muse/readers/csv.py
+++ b/src/muse/readers/csv.py
@@ -361,7 +361,7 @@ def read_technologies(
 
         else:
             raise IOError(
-                f"Commodities not found in global commodities file. Check spelling of names across input and sector data."
+                "Commodities not found in global commodities file. Check spelling of names across input and sector data."
             )
 
     result["comm_usage"] = (

--- a/src/muse/readers/csv.py
+++ b/src/muse/readers/csv.py
@@ -361,7 +361,7 @@ def read_technologies(
 
         else:
             raise IOError(
-                "Commodities not found in global commodities file. Check spelling of names across input and sector data."
+                "Commodities not found in global commodities file: check spelling."
             )
 
     result["comm_usage"] = (


### PR DESCRIPTION
# Description

Solves one cause of the empty technology error, when this is due to a modelling error. Change from warning to import/export error when commodities are not consistent between global commodities and sector data.

Fixes #38 

## Type of change

Please add a line in the relevant section of
[CHANGELOG.md](https://github.com/SGIModel/StarMuse/blob/development/CHANGELOG.md) to
document the change (include PR #) - note reverse order of PR #s.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass: `$ python -m pytest`
- [ ] The documentation builds and looks OK: `$ python setup.py build_sphinx`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
