### PR TITLE
Remove retro docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- Add error about not finding interaction network ([50](https://github.com/SGIModel/MUSE_OS/pull/50))
 - Add option for `standard_demand` and remove retro agents ([#35](https://github.com/SGIModel/MUSE_OS/pull/35))
 - Update main version ([#28](https://github.com/SGIModel/MUSE_OS/pull/28))
 - Update main version ([#26](https://github.com/SGIModel/MUSE_OS/pull/26))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- Update documentation about not using retrofit ([51](https://github.com/SGIModel/MUSE_OS/pull/51))
 - Add error about not finding interaction network ([50](https://github.com/SGIModel/MUSE_OS/pull/50))
 - Add option for `standard_demand` and remove retro agents ([#35](https://github.com/SGIModel/MUSE_OS/pull/35))
 - Update main version ([#28](https://github.com/SGIModel/MUSE_OS/pull/28))

--- a/docs/inputs/agents.rst
+++ b/docs/inputs/agents.rst
@@ -40,7 +40,9 @@ Type
    invest only to make up for decommissioned assets. They are often limited in the
    technologies they can consider (by :ref:`SearchRule <SearchRule>`). "New" agents
    invest on the rest of the demand, and can often consider more general sets of
-   technologies.
+   technologies. If only "New" agents are included, they will also invest to make up for
+   decomissioned assets, but the end mix might be different than using a specialised
+   "Retrofit" agent for that.
 
 AgentShare
    Name of the share of the existing capacity assigned to this agent. Only meaningful

--- a/docs/inputs/toml.rst
+++ b/docs/inputs/toml.rst
@@ -85,7 +85,7 @@ plugins
 outputs_cache
    This option behaves exactly like `outputs` below for sectors and accepts the same options but
    controls the output of cached quantities instead. This option is NOT available for
-   sectors themse;ves (i.e using `[[sector.comercial.outputs_cache]]` will have no effect). See
+   sectors themselves (i.e using `[[sector.comercial.outputs_cache]]` will have no effect). See
    :py:mod:`muse.outputs.cache` for more details.
 
    A single row looks like this:
@@ -340,8 +340,13 @@ dispatch_production
 
 demand_share
     A method used to split the MCA demand into seperate parts to be serviced by specific
-    agents. There is currently only one option, "new_and_retro", corresponding to *new*
-    and *retro* agents.
+    agents. There is currently two options:
+   
+   - "standard_demand", where all the demand is split among the "new" agents, raising
+     and error if retro agents are found for the sector.
+   - "new_and_retro", corresponding to splitting the demand among *new* and *retro* 
+      agents, in adition to splitting it between agents of the same type.
+
 
 interactions
    Defines interactions between agents. These interactions take place right before new
@@ -390,6 +395,10 @@ interactions
    The parameters will depend on the net and interaction functions. Neither
    "new_to_retro" nor "transfer" take any arguments at this point. MUSE interaction
    facilities are defined in :py:mod:`muse.interactions`.
+
+   An error is raised if and empty network is found. This is the case, for example, if a
+   "new_to_retro" type of network has been defined but no retro agents are included in
+   the sector.
 
 
 output

--- a/docs/inputs/toml.rst
+++ b/docs/inputs/toml.rst
@@ -339,8 +339,8 @@ dispatch_production
    It has the same format and options as the *production* attribute above.
 
 demand_share
-    A method used to split the MCA demand into seperate parts to be serviced by specific
-    agents. There is currently two options:
+   A method used to split the MCA demand into seperate parts to be serviced by specific
+   agents. There is currently two options:
    
    - "standard_demand", where all the demand is split among the "new" agents, raising
      and error if retro agents are found for the sector.

--- a/src/muse/errors.py
+++ b/src/muse/errors.py
@@ -81,3 +81,14 @@ section for each of the selected sectors to model."""
 
     def __str__(self):
         return self.msg
+
+
+class NoInteractionsFound(Exception):
+
+    msg = """A network with no interactions has been found. This might be the case if
+there are no retrofit agents and yet a 'new_to_retro' network has been defined for a
+particular sector. Asses the existance of both new and retrofit agents for all sectors
+and remove the new_to_retro interacton network if it is not needed """
+
+    def __str__(self):
+        return self.msg

--- a/src/muse/interactions.py
+++ b/src/muse/interactions.py
@@ -24,6 +24,7 @@ __all__ = [
 from typing import Callable, List, Mapping, Optional, Sequence, Text, Tuple, Union
 
 from muse.agents import AbstractAgent, Agent
+from muse.errors import NoInteractionsFound
 from muse.registration import registrator
 
 AGENT_INTERACTIONS: Mapping[Text, Callable] = {}
@@ -117,6 +118,9 @@ def factory(
         for (net, net_params), (interaction, interaction_params) in interactions:
             nparams = {k: v for k, v in net_params.items() if k != "name"}
             sets = net(agents, **nparams)
+
+            if len(sets) == 0:
+                raise NoInteractionsFound
 
             getLogger(__name__).info(
                 f"Net {net_params['name']} of {len(sets)} interactions interacting "

--- a/src/muse/interactions.py
+++ b/src/muse/interactions.py
@@ -112,7 +112,10 @@ def factory(
         interactions.append(((net, net_params), (interaction, action_params)))
 
     def compute_interactions(agents: Sequence[AbstractAgent]) -> None:
-        """Applies interaction net and agent interaction functions."""
+        """Applies interaction net and agent interaction functions.
+
+        If a network is found with no interactions, an error is raised.
+        """
         from logging import getLogger
 
         for (net, net_params), (interaction, interaction_params) in interactions:

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -1,5 +1,6 @@
 """Test agent interactions."""
 
+import pytest
 from pytest import fixture, mark
 
 
@@ -56,6 +57,7 @@ def test_new_to_retro_net(agents):
 
 @mark.usefixtures("save_registries")
 def test_compute_interactions(agents):
+    from muse.errors import NoInteractionsFound
     from muse.interactions import factory, new_to_retro_net, register_agent_interaction
 
     @register_agent_interaction
@@ -74,3 +76,7 @@ def test_compute_interactions(agents):
     assert len(new_to_retro_net(agents)) == 0 or len(not_none) != 0
     for agent in not_none:
         assert agent.assets[0].assets[0] is agent
+
+    agents2 = [a for a in agents if a.category == "nope"]
+    with pytest.raises(NoInteractionsFound):
+        interactions(agents2)


### PR DESCRIPTION
# Description

Updates the documentation explaining the use of `standard_demand` and the possibility of not using retrofit agents

Fixes #47

## Type of change

Please add a line in the relevant section of
[CHANGELOG.md](https://github.com/SGIModel/StarMuse/blob/development/CHANGELOG.md) to
document the change (include PR #) - note reverse order of PR #s.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass: `$ python -m pytest`
- [x] The documentation builds and looks OK: `$ python setup.py build_sphinx`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
