### PR TITLE
Test no retro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- Add tests to check the case of not using retrofit agents ([#53](https://github.com/SGIModel/MUSE_OS/pull/53))
 - Add a tutorial for caching quantities and fix a bug in the caching pipeline ([#52](https://github.com/SGIModel/MUSE_OS/pull/52))
 - Update documentation about not using retrofit ([51](https://github.com/SGIModel/MUSE_OS/pull/51))
 - Add error about not finding interaction network ([50](https://github.com/SGIModel/MUSE_OS/pull/50))

--- a/src/muse/hooks.py
+++ b/src/muse/hooks.py
@@ -71,6 +71,7 @@ def asset_merge_factory(settings: Union[Text, Mapping] = "new") -> Callable:
     def final_assets_transform(old_assets: Dataset, new_assets):
         return transform(old_assets, new_assets, **params)
 
+    final_assets_transform.__name__ = name
     return final_assets_transform
 
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -58,6 +58,61 @@ def test_create_retrofit(agent_args, technologies, stock):
     assert isinstance(agent, Agent)
     assert "asset" in agent.assets.dims
     assert len(agent.assets.capacity) != 0
+    assert (agent.assets.capacity != 0).any()
+
+
+def test_create_newcapa(agent_args, technologies, stock):
+    from muse.agents.agent import Agent
+    from muse.agents.factories import create_agent
+
+    # If there is no retrofit, new capa should behave identical to retrofit.
+    agent_args["share"] = "agent_share_zero"
+    agent_args["retrofit_present"] = False
+    agent = create_agent(
+        agent_type="Newcapa",
+        technologies=technologies,
+        capacity=stock.capacity,
+        year=2010,
+        **agent_args,
+    )
+    assert isinstance(agent, Agent)
+    assert len(agent.assets.capacity) == 0
+    assert "asset" in agent.assets.dims and len(agent.assets.asset) == 0
+    assert "year" in agent.assets.dims or len(agent.assets.year) > 1
+    assert "region" not in agent.assets.dims
+    assert "commodity" not in agent.assets.dims
+    assert agent.merge_transform.__name__ == "merge"
+
+    agent_args["share"] = "agent_share"
+    agent = create_agent(
+        agent_type="Newcapa",
+        technologies=technologies,
+        capacity=stock.capacity,
+        year=2010,
+        **agent_args,
+    )
+    assert isinstance(agent, Agent)
+    assert "asset" in agent.assets.dims
+    assert len(agent.assets.capacity) != 0
+    assert (agent.assets.capacity != 0).any()
+    assert agent.merge_transform.__name__ == "merge"
+
+    # If there are retrofit agents, these are really newcapa agents with no capacity
+    agent_args["share"] = "agent_share"
+    agent_args["retrofit_present"] = True
+    agent = create_agent(
+        agent_type="Newcapa",
+        technologies=technologies,
+        capacity=stock.capacity,
+        year=2010,
+        **agent_args,
+    )
+
+    assert isinstance(agent, Agent)
+    assert "asset" in agent.assets.dims
+    assert len(agent.assets.capacity) != 0
+    assert (agent.assets.capacity == 0).all()
+    assert agent.merge_transform.__name__ == "new"
 
 
 def test_issue_835_and_842(agent_args, technologies, stock):


### PR DESCRIPTION
# Description

Add tests to check the functionality added when not using retrofit agents, in particular the new capacity agent creation if there are no retro and the standard demand. 

Fixes #53

## Type of change

Please add a line in the relevant section of
[CHANGELOG.md](https://github.com/SGIModel/StarMuse/blob/development/CHANGELOG.md) to
document the change (include PR #) - note reverse order of PR #s.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass: `$ python -m pytest`
- [x] The documentation builds and looks OK: `$ python setup.py build_sphinx`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
