### PR TITLE
Added GitHub workflow to check for broken links

### DIFF
--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -3,8 +3,8 @@ on:
     - cron: 0 0 1 * * # run monthly
   repository_dispatch: # run manually
     types: [check-link]
-  # push:
-  # ...
+  push:
+    branches: [develop, broken_link_checker]
 
 name: Broken Link Check
 jobs:

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -1,0 +1,19 @@
+on:
+  schedule:
+    - cron: 0 0 1 * * # run monthly
+  repository_dispatch: # run manually
+    types: [check-link]
+  # push:
+  # ...
+
+name: Broken Link Check
+jobs:
+  check:
+    name: Broken Link Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Broken Link Check
+        uses: technote-space/broken-link-checker-action@v2
+        with:
+          TARGET: https://muse-os.readthedocs.io/en/latest/
+

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -1,8 +1,10 @@
 on:
   schedule:
     - cron: 0 0 1 * * # run monthly
+  repository_dispatch: # run manually
+    types: [check-link]
   push:
-    branches: [develop, broken_link_checker]
+    branches: [main, develop_imperial]
 
 name: Broken Link Check
 jobs:
@@ -14,4 +16,4 @@ jobs:
         uses: ruzickap/action-my-broken-link-checker@v2
         with:
           url: https://muse-os.readthedocs.io/en/latest/
-          cmd_params: '--buffer-size=8192 --max-connections=3 --color=always --skip-tls-verification --header="User-Agent:curl/7.54.0" --timeout=10'  # muffet parameters
+          cmd_params: '--buffer-size=8192 --max-connections=3 --color=always --skip-tls-verification --header="User-Agent:curl/7.54.0"'  # muffet parameters

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -1,8 +1,6 @@
 on:
   schedule:
     - cron: 0 0 1 * * # run monthly
-  repository_dispatch: # run manually
-    types: [check-link]
   push:
     branches: [develop, broken_link_checker]
 
@@ -13,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Broken Link Check
-        uses: technote-space/broken-link-checker-action@v2
+        uses: ruzickap/action-my-broken-link-checker@v2
         with:
-          TARGET: https://muse-os.readthedocs.io/en/latest/
-          RECURSIVE: true
+          url: https://muse-os.readthedocs.io/en/latest/
+          cmd_params: '--buffer-size=8192 --max-connections=3 --color=always --skip-tls-verification --header="User-Agent:curl/7.54.0" --timeout=10'  # muffet parameters

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -16,4 +16,4 @@ jobs:
         uses: technote-space/broken-link-checker-action@v2
         with:
           TARGET: https://muse-os.readthedocs.io/en/latest/
-
+          RECURSIVE: true


### PR DESCRIPTION
# Description
This PR adds a new GitHub workflow to check the links in the MUSE readthedocs.io documentation. This is helpful since URLs often stop working as time goes by - this therefore provides an automated way of monitoring for those and flagging them to be sorted

Fixes #102 

## Type of change

Please add a line in the relevant section of
[CHANGELOG.md](https://github.com/SGIModel/StarMuse/blob/development/CHANGELOG.md) to
document the change (include PR #) - note reverse order of PR #s.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass: `$ python -m pytest`
- [ ] The documentation builds and looks OK: `$ python setup.py build_sphinx`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
