### PR TITLE
Convert setup.cfg to pyproject.toml and add entrypoint.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,4 +2,127 @@
 requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
 build-backend = "setuptools.build_meta"
 
+[project]
+name = "MUSE"
+authors = [
+    {name = "Sustainable Gas Institute", email = "sgi@imperial.ac.uk"},
+]
+description = "Energy System Model"
+readme = "README.md"
+requires-python = ">= 3.7"
+keywords = ["energy", "modelling"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python :: 3.8",
+    "Intended Audience :: Science",
+    "Intended Audience :: Research",
+    "Intended Audience :: Economists",
+    "Intended Audience :: Energy Experts",
+    "Intended Audience :: Climate Mitigation Experts",
+    "Intended Audience :: Industry",
+]
+dependencies = [
+    "numpy==1.23.0",
+    "scipy",
+    "pandas<=1.3",
+    "click",
+    "xarray==2022.3.0",
+    "bottleneck",
+    "coloredlogs",
+    "toml",
+    "xlrd==1.2.0",
+    "mypy-extensions",
+    "pypubsub",
+]
+dynamic = ["version"]
+
+[project.urls]
+Homepage = "http://www.sustainablegasinstitute.org/home/muse-energy-model/"
+
+[project.optional-dependencies]
+all = ["MUSE[dev,doc,excel]"]
+dev = [
+    "pytest>4.0.2",
+    "flake8!=3.8.1,!=3.8.0,<4.0.0",
+    "black",
+    "pytest-flake8",
+    "IPython",
+    "jupyter",
+    "nbconvert",
+    "nbformat",
+    "mypy",
+    "numpy>=1.17",
+    "pytest-xdist",
+    "bump2version",
+]
+doc = [
+    "sphinx==5.0.2",
+    "ipykernel",
+    "nbsphinx",
+    "myst-parser",
+    "sphinxcontrib-bibtex",
+    "ipython",
+    "pandoc",
+]
+excel = ["openpyxl"]
+private_sgi_model = [
+    "SGIModelData @ git+https://github.com/SGIModel/SGIModelData.git@master",
+    "StarMUSELegacy @ git+https://github.com/SGIModel/StarMuse.git@archive/legacy",
+]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["src"]
+namespaces = false
+
+[tool.setuptools.package-data]
+"*" = ["**/*.toml", "**/*.csv"]
+
+[tool.setuptools.dynamic]
+version = {attr = "muse.VERSION"}
+
 [tool.setuptools_scm]
+
+[tool.pyls]
+configurationsources = ['flake8']
+
+[tool.aliases]
+test = "pytest"
+
+[tool.pytest.ini_options]
+testpaths = ["tests", "src/muse"]
+addopts = "--doctest-modules --flake8 -rfE -n auto"
+markers = [
+    "sgidata: test that require legacy data",
+    "legacy: test that require legacy modules",
+    "regression: a regression test",
+    "notebook: a test which consist in running a jupyter notebook",
+]
+
+[tool.pycodestyle]
+max-line-length = "88"
+ignore = ["E203", "W503"]
+
+[tool.mypy]
+ignore_missing_imports = true
+strict_optional = true
+files = ["src/**/*.py", "tests/**/*.py"]
+
+[[tool.mypy.overrides]]
+module = ["setup"]
+ignore_errors = true
+
+[tool.isort]
+line_length = 88
+multi_line_output = 3
+include_trailing_comma = true
+
+[tool.build_sphinx]
+project = "'MUSE'"
+version = "attr: muse.VERSION"
+release = "attr: muse.VERSION"
+source-dir = "docs"
+build-dir = "docs/build"

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,103 +3,9 @@ current_version = "1.0"
 commit = True
 tag = True
 
-[metadata]
-name = MUSE
-version = attr: src.muse.VERSION
-description = Energy System Model
-classifiers = 
-	Development Status :: 3 - Alpha
-	Programming Language :: Python :: 3.8
-	Intended Audience :: Science
-	Intended Audience :: Research
-	Intended Audience :: Economists
-	Intended Audience :: Energy Experts
-	Intended Audience :: Climate Mitigation Experts
-	Intended Audience :: Industry
-keywords = ["energy", "modelling"]
-author = Sustainable Gas Institute
-author_email = sgi@imperial.ac.uk
-url = http://www.sustainablegasinstitute.org/home/muse-energy-model/
-
-[options]
-python_requires = >= 3.7
-package_dir = 
-	=src
-packages = find:
-include_package_data = True
-install_requires = 
-	numpy==1.23.0
-	scipy
-	pandas<=1.3
-	click
-	xarray==2022.3.0
-	bottleneck
-	coloredlogs
-	toml
-	xlrd==1.2.0
-	mypy-extensions
-	pypubsub
-
-[options.packages.find]
-where = src
-
-[options.package_data]
-* = **/*.toml, **/*.csv
-
-[options.extras_require]
-all = 
-	%(dev)s
-	%(doc)s
-	%(excel)s
-dev = 
-	pytest>4.0.2
-	flake8!=3.8.1,!=3.8.0,<4.0.0
-	black
-	pytest-flake8
-	IPython
-	jupyter
-	nbconvert
-	nbformat
-	mypy
-	numpy>=1.17
-	pytest-xdist
-	bump2version
-doc = 
-	sphinx==5.0.2
-	ipykernel
-	nbsphinx
-	myst-parser
-	sphinxcontrib-bibtex
-	ipython
-	pandoc
-excel = 
-	openpyxl
-private_sgi_model = 
-	SGIModelData @ git+https://github.com/SGIModel/SGIModelData.git@master
-	StarMUSELegacy @ git+https://github.com/SGIModel/StarMuse.git@archive/legacy
-
 [bumpversion:file:src/muse/__init__.py]
 
 [bumpversion:file:docs/conf.py]
-
-[pyls]
-configurationSources = ['flake8']
-
-[aliases]
-test = pytest
-
-[tool:pytest]
-testpaths = tests src/muse
-addopts = --doctest-modules --flake8 -rfE -n auto
-markers = 
-	sgidata: test that require legacy data
-	legacy: test that require legacy modules
-	regression: a regression test
-	notebook: a test which consist in running a jupyter notebook
-
-[pycodestyle]
-max-line-length = 88
-ignore = E203,W503
 
 [flake8]
 max-line-length = 88
@@ -109,23 +15,3 @@ exclude =
 	build,
 	__pycache__,
 ignore = E203,W503
-
-[mypy]
-ignore_missing_imports = True
-strict_optional = True
-files = src/**/*.py,tests/**/*.py
-
-[mypy-setup]
-ignore_errors = True
-
-[isort]
-line_length = 88
-multi_line_output = 3
-include_trailing_comma = true
-
-[build_sphinx]
-project = 'MUSE'
-version = attr: src.muse.VERSION
-release = attr: src.muse.VERSION
-source-dir = docs
-build-dir = docs/build

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-import setuptools
-
-setuptools.setup()

--- a/src/muse/__main__.py
+++ b/src/muse/__main__.py
@@ -1,5 +1,6 @@
 """Makes MUSE executable."""
 import click
+
 INPUT_PATH = click.Path(exists=False, file_okay=True, resolve_path=True)
 MODEL_PATH = click.Path(file_okay=False, resolve_path=True)
 MODELS = click.Choice(
@@ -51,5 +52,6 @@ def muse_main(settings, model, copy):
 
 if "__main__" == __name__:
     from sys import argv, executable
+
     argv[0] = "%s -m muse" % executable
     muse_main()

--- a/src/muse/demand_share.py
+++ b/src/muse/demand_share.py
@@ -99,7 +99,7 @@ def factory(
         agents: Sequence[AbstractAgent],
         market: xr.Dataset,
         technologies: xr.Dataset,
-        **kwargs
+        **kwargs,
     ) -> xr.DataArray:
         from copy import copy
 

--- a/src/muse/filters.py
+++ b/src/muse/filters.py
@@ -214,12 +214,12 @@ def factory(
     functions = [
         partial(
             SEARCH_SPACE_INITIALIZERS[initial_settings["name"]],
-            **{k: v for k, v in initial_settings.items() if k != "name"}
+            **{k: v for k, v in initial_settings.items() if k != "name"},
         ),
         *(
             partial(
                 SEARCH_SPACE_FILTERS[setting["name"]],
-                **{k: v for k, v in setting.items() if k != "name"}
+                **{k: v for k, v in setting.items() if k != "name"},
             )
             for setting in parameters
         ),
@@ -242,7 +242,7 @@ def same_enduse(
     technologies: xr.Dataset,
     *args,
     enduse_label: Text = "service",
-    **kwargs
+    **kwargs,
 ) -> xr.DataArray:
     """Only allow for technologies with at least the same end-use."""
     from muse.commodities import is_enduse
@@ -335,7 +335,7 @@ def maturity(
     technologies: xr.Dataset,
     market: xr.Dataset,
     enduse_label: Text = "service",
-    **kwargs
+    **kwargs,
 ) -> xr.DataArray:
     """Only allows technologies that have achieve a given market share.
 
@@ -359,7 +359,7 @@ def spend_limit(
     technologies: xr.Dataset,
     market: xr.Dataset,
     enduse_label: Text = "service",
-    **kwargs
+    **kwargs,
 ) -> xr.DataArray:
     """Only allows technologies that have achieve a given market share.
 
@@ -381,7 +381,7 @@ def compress(
     search_space: xr.DataArray,
     technologies: xr.Dataset,
     market: xr.Dataset,
-    **kwargs
+    **kwargs,
 ) -> xr.DataArray:
     """Compress search space to include only potential technologies.
 
@@ -405,7 +405,7 @@ def reduce_asset(
     search_space: xr.DataArray,
     technologies: xr.Dataset,
     market: xr.Dataset,
-    **kwargs
+    **kwargs,
 ) -> xr.DataArray:
     """Reduce over assets."""
     return search_space.any("asset") if "asset" in search_space.dims else search_space
@@ -417,7 +417,7 @@ def with_asset_technology(
     search_space: xr.DataArray,
     technologies: xr.Dataset,
     market: xr.Dataset,
-    **kwargs
+    **kwargs,
 ) -> xr.DataArray:
     """Search space *also* contains its asset technology for each asset."""
     return search_space | (search_space.asset == search_space.replacement)
@@ -447,7 +447,7 @@ def initialize_from_assets(
     technologies: xr.Dataset,
     *args,
     coords: Sequence[Text] = ("region", "technology"),
-    **kwargs
+    **kwargs,
 ):
     """Initialize a search space from existing technologies."""
     from muse.utilities import reduce_assets


### PR DESCRIPTION
# Description

Moved most of that is possible from setup.cfg into pyproject.toml.

Added an entry point via src/muse/main.py to pyproject.toml. MUSE can now be called via `muse` command after installation

bumpversion and flake8 do not yet support pyproject.toml, and remain in setup.cfg.

NEEDS INFO: `bump2version` fails doe to incorrect initial version in setup.cfg bumpversion

Fixes #103 
Fixes #108 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass: `$ python -m pytest`
- [ ] The documentation builds and looks OK: `$ python setup.py build_sphinx`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
