### PR TITLE
Update pyproject.toml with license information

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,14 +9,16 @@ authors = [
 ]
 description = "Energy System Model"
 readme = "README.md"
+license = {file = "LICENSE"}
 requires-python = ">= 3.8, <3.10"
 keywords = ["energy", "modelling"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Intended Audience :: Science/Research",
     "Intended Audience :: Other Audience",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 ]
 dependencies = [
     "numpy==1.23.0",


### PR DESCRIPTION
# Description

License metadata was missing from `pyproject.toml`. This PR adds that metadata and also bumps the status to `Beta`, as MUSE is most definitely more stable that what `Alpha` status generally suggests. 

Having the license in `pyproject.toml` will also show the correct badge in the README after a new version is released. 

Fixes #128 

## Type of change

Please add a line in the relevant section of
[CHANGELOG.md](https://github.com/SGIModel/StarMuse/blob/development/CHANGELOG.md) to
document the change (include PR #) - note reverse order of PR #s.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

N/A

- [ ] All tests pass: `$ python -m pytest`
- [ ] The documentation builds and looks OK: `$ python -m sphinx -b html docs docs/build`

## Further checks

N/A

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
