### PR TITLE
Run link-checker only once a week

### DIFF
--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -1,12 +1,8 @@
 on:
   schedule:
-    - cron: 0 0 1 * * # run monthly
+    - cron: 0 0 * * 0 # At 12:00 AM, only on Sunday
   repository_dispatch: # run manually
     types: [check-link]
-  push:
-    branches: [main, develop]
-  pull_request:
-      types: [opened, synchronize, reopened]
 
 name: Broken Link Check
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- Run link-checker only once a week ([#148](https://github.com/SGIModel/MUSE_OS/pull/148))
 - Update documentation for installing MUSE ([#138](https://github.com/SGIModel/MUSE_OS/pull/138))
 - Updating pyproject.toml with valid python versions ([#121](https://github.com/SGIModel/MUSE_OS/pull/121))
 - Expand CI workflow ([#119](https://github.com/SGIModel/MUSE_OS/pull/119))


### PR DESCRIPTION
# Description

Updates the relevant workflow file to run the links checker of the documentation only automatically on Sundays (or manually), rather than when there are PRs or pushes to any branch.

Fixes #147

## Type of change

Please add a line in the relevant section of
[CHANGELOG.md](https://github.com/SGIModel/StarMuse/blob/development/CHANGELOG.md) to
document the change (include PR #) - note reverse order of PR #s.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist
N/A
- [ ] All tests pass: `$ python -m pytest`
- [ ] The documentation builds and looks OK: `$ python -m sphinx -b html docs docs/build`

## Further checks
N/A
- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
