### PR TITLE
Add a coverage configuration to ease coverage gateway

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 3%


### PR DESCRIPTION
Adds a coverage configuration such that even if coverage goes slightly down in a PR, the CI does not fail. 
